### PR TITLE
chore: Add osx-arm64 platform support to pixi config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ scikit-learn = ">=1.3"
 xgboost = ">=2.0"
 imbalanced-learn = ">=0.11"
 pennylane = ">=0.36"
-pennylane-lightning = ">=0.36"
+autoray = "<0.7"
 matplotlib = ">=3.7"
 seaborn = ">=0.13"
 jupyter = ">=1.0"
@@ -34,6 +34,7 @@ pytest = ">=7.4"
 pytest-cov = ">=4.1"
 
 [tool.pixi.pypi-dependencies]
+pennylane-lightning = ">=0.36"
 qml_fraud_detection_benchmark = { path = ".", editable = true }
 
 [tool.pixi.tasks]


### PR DESCRIPTION
## Summary
- Add `osx-arm64` to pixi platforms (alongside existing `linux-64`)
- Move `pennylane-lightning` to `pypi-dependencies` (not available on conda-forge for osx-arm64)
- Pin `autoray<0.7` to fix pennylane 0.36 incompatibility with autoray 0.8.x

## Test plan
- [x] `pixi install` resolves cleanly on osx-arm64 (M4 Mac Mini)
- [x] All 37 tests pass: `pixi run pytest tests/ -v --ignore=tests/test_noise.py`