### PR TITLE
feat: Add --qsvm-only flag and granular VQC/QSVM watcher queue

### DIFF
--- a/run_noise.py
+++ b/run_noise.py
@@ -85,7 +85,8 @@ def _parse_args() -> argparse.Namespace:
     )
     p.add_argument("--noise-dir",  type=Path, default=NOISE_DIR,
                    help="Output directory for this run's results.")
-    p.add_argument("--vqc-only",   action="store_true", help="Skip QSVM (faster).")
+    p.add_argument("--vqc-only",   action="store_true", help="Skip QSVM, run VQC only.")
+    p.add_argument("--qsvm-only",  action="store_true", help="Skip VQC, run QSVM only.")
     p.add_argument("--no-plots",   action="store_true")
     p.add_argument("--log-level",  choices=["DEBUG", "INFO", "WARNING"], default="INFO")
 
@@ -332,17 +333,18 @@ def main() -> None:
     for p in args.noise_levels:
         logging.info("\n%s\n  noise_level = %.4f\n%s", "=" * 50, p, "=" * 50)
 
-        t0 = time.perf_counter()
-        res = _run_vqc(
-            data.X_train, data.y_train,
-            data.X_val,   data.y_val,
-            data.X_test,  data.y_test,
-            args.n_qubits, p, rng,
-        )
-        quantum_results.append(res)
-        logging.info("VQC  p=%.4f | F1-fraud=%.4f MCC=%.4f | %.1f s",
-                     p, res["metrics"]["f1_fraud"], res["metrics"]["mcc"],
-                     time.perf_counter() - t0)
+        if not args.qsvm_only:
+            t0 = time.perf_counter()
+            res = _run_vqc(
+                data.X_train, data.y_train,
+                data.X_val,   data.y_val,
+                data.X_test,  data.y_test,
+                args.n_qubits, p, rng,
+            )
+            quantum_results.append(res)
+            logging.info("VQC  p=%.4f | F1-fraud=%.4f MCC=%.4f | %.1f s",
+                         p, res["metrics"]["f1_fraud"], res["metrics"]["mcc"],
+                         time.perf_counter() - t0)
 
         if not args.vqc_only:
             t0 = time.perf_counter()

--- a/run_noise_watcher.sh
+++ b/run_noise_watcher.sh
@@ -1,65 +1,89 @@
 #!/usr/bin/env bash
 # run_noise_watcher.sh
-# Monitors running noise sweep processes. As soon as any one finishes,
-# launches the next queued level. Then merges all results when everything is done.
+# Monitors running noise sweep processes. As soon as any slot frees up,
+# launches the next queued job (VQC-only first, then QSVM-only per level).
+# Auto-merges and plots when everything is done.
+#
+# Queue order for remaining levels:
+#   p=0.02 VQC → p=0.05 VQC → p=0.02 QSVM → p=0.05 QSVM
+# VQC jobs go first so QSVM can start as early as possible.
 
 set -euo pipefail
 
 BASE_DIR="results/noise"
 ENV_VARS="OMP_NUM_THREADS=10 OPENBLAS_NUM_THREADS=10 VECLIB_MAXIMUM_THREADS=10 MKL_NUM_THREADS=10 NUMEXPR_NUM_THREADS=10"
-QUEUE=(0.02 0.05)
 ALL_LEVELS=(0.0 0.001 0.005 0.01 0.02 0.05)
+
+# Each entry: "noise_level:mode"  mode = vqc | qsvm
+QUEUE=(
+    "0.02:vqc"
+    "0.05:vqc"
+    "0.02:qsvm"
+    "0.05:qsvm"
+)
 QUEUE_IDX=0
 
 log() { echo "[$(date +%H:%M:%S)] $*"; }
 
 launch_next() {
-    if [ $QUEUE_IDX -lt ${#QUEUE[@]} ]; then
-        local P="${QUEUE[$QUEUE_IDX]}"
-        local DIR="$BASE_DIR/p${P}"
-        mkdir -p "$DIR"
-        log "Launching p=$P → $DIR"
-        env $ENV_VARS pixi run python run_noise.py sweep \
-            --data-path data/raw/creditcard.csv \
-            --n-qubits 8 \
-            --noise-levels "$P" \
-            --noise-dir "$DIR" \
-            --no-plots \
-            > "$DIR/run.log" 2>&1 &
-        log "p=$P launched (PID $!)"
-        QUEUE_IDX=$((QUEUE_IDX + 1))
+    if [ $QUEUE_IDX -ge ${#QUEUE[@]} ]; then
+        return
     fi
+
+    local ENTRY="${QUEUE[$QUEUE_IDX]}"
+    local P="${ENTRY%%:*}"
+    local MODE="${ENTRY##*:}"
+    local DIR="$BASE_DIR/p${P}"
+    mkdir -p "$DIR"
+
+    local FLAG=""
+    [ "$MODE" = "vqc" ]  && FLAG="--vqc-only"
+    [ "$MODE" = "qsvm" ] && FLAG="--qsvm-only"
+
+    log "Launching p=$P ($MODE) → $DIR"
+    env $ENV_VARS pixi run python run_noise.py sweep \
+        --data-path data/raw/creditcard.csv \
+        --n-qubits 8 \
+        --noise-levels "$P" \
+        --noise-dir "$DIR" \
+        --no-plots \
+        $FLAG \
+        >> "$DIR/run.log" 2>&1 &
+    log "  PID $!"
+    QUEUE_IDX=$((QUEUE_IDX + 1))
 }
 
-log "Watcher started. Monitoring p=0.001, p=0.005, p=0.01..."
+log "Watcher started (granular VQC/QSVM mode)."
 log "Queue: ${QUEUE[*]}"
+log "Monitoring current processes..."
 
 PREV_COUNT=$(ps aux | grep "run_noise.py sweep" | grep -v grep | wc -l | tr -d ' ')
 
 while true; do
-    sleep 120  # check every 2 minutes
+    sleep 120
 
     CURR_COUNT=$(ps aux | grep "run_noise.py sweep" | grep -v grep | wc -l | tr -d ' ')
 
     if [ "$CURR_COUNT" -lt "$PREV_COUNT" ]; then
         FINISHED=$((PREV_COUNT - CURR_COUNT))
-        log "$FINISHED process(es) finished. Running: $CURR_COUNT"
-        # Launch one queued level per finished process
+        log "$FINISHED slot(s) freed. Running: $CURR_COUNT. Launching next..."
         for ((i=0; i<FINISHED; i++)); do
             launch_next
         done
+        PREV_COUNT=$(ps aux | grep "run_noise.py sweep" | grep -v grep | wc -l | tr -d ' ')
+    else
         PREV_COUNT=$CURR_COUNT
     fi
 
-    # Check if everything is done
+    # Done when no processes running and queue exhausted
     CURR_COUNT=$(ps aux | grep "run_noise.py sweep" | grep -v grep | wc -l | tr -d ' ')
     if [ "$CURR_COUNT" -eq 0 ] && [ "$QUEUE_IDX" -ge "${#QUEUE[@]}" ]; then
-        log "All levels done. Merging..."
+        log "All jobs done. Merging..."
         break
     fi
 done
 
-# Merge all results + generate plot
+# Merge + plot
 DIRS=()
 for P in "${ALL_LEVELS[@]}"; do
     DIRS+=("$BASE_DIR/p${P}")


### PR DESCRIPTION
## Summary
- Add `--qsvm-only` flag to `run_noise.py sweep` to run only the QSVM phase (complements existing `--vqc-only`)
- Update `run_noise_watcher.sh` to use granular queue: VQC jobs first, then QSVM — so QSVM can start as soon as a slot frees up rather than waiting for the full pipeline

## Queue order
0.02 VQC → 0.05 VQC → 0.02 QSVM → 0.05 QSVM

## Test plan
- [x] `--vqc-only` and `--qsvm-only` both appear in `sweep --help`
- [x] Watcher confirmed running with new granular queue