### PR TITLE
docs: Update README with benchmark results and learnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,28 @@
 
 ---
 
+## Key Findings
+
+**Quantum advantage was not demonstrated in this setting.**
+
+| Model | F1-Fraud | MCC | ROC-AUC | PR-AUC |
+|---|---|---|---|---|
+| XGBoost | **0.924** | **0.900** | 0.974 | 0.968 |
+| Random Forest | 0.917 | 0.894 | **0.983** | **0.974** |
+| QSVM (p=0.0) | 0.905 | 0.871 | 0.963 | 0.952 |
+| VQC (p=0.0) | 0.699 | 0.626 | 0.875 | 0.785 |
+
+- **QSVM** is competitive — within ~1.3% F1 of Random Forest at zero noise — but does not exceed classical baselines.
+- **VQC** underperforms significantly (~22% below XGBoost). The bottleneck is model capacity (8 qubits / 30 epochs), not noise.
+- Both quantum models remain below classical at all depolarizing noise levels tested (p = 0.0 → 0.05).
+
+See the [noise sweep results notebook](notebooks/02_noise_sweep_results.ipynb) for the full analysis.
+
+---
+
 ## Overview
 
-This repository implements a rigorous benchmarking framework that compares:
+This repository implements a rigorous benchmarking framework comparing quantum and classical models on credit card fraud detection:
 
 | Model | Type | Library |
 |---|---|---|
@@ -16,10 +35,10 @@ This repository implements a rigorous benchmarking framework that compares:
 | Variational Quantum Classifier (VQC) | Quantum | PennyLane |
 | Quantum Support Vector Machine (QSVM) | Quantum | PennyLane + scikit-learn |
 
-The benchmark is designed around the challenges specific to financial fraud detection:
+The benchmark is designed around the specific challenges of financial fraud detection:
 - **Extreme class imbalance** (~0.17% fraud in the reference dataset)
 - **High dimensionality** vs. the limited qubit count of NISQ simulators
-- **Rigorous metrics** that reflect real-world fraud detection performance
+- **Rigorous metrics** — F1-Fraud, MCC, PR-AUC, ROC-AUC (accuracy is reported as reference only)
 
 ---
 
@@ -28,26 +47,27 @@ The benchmark is designed around the challenges specific to financial fraud dete
 ```
 qml-fraud-detection-benchmark/
 ├── data/
-│   ├── raw/                  # Place creditcard.csv here
-│   └── processed/            # Auto-generated preprocessed arrays
+│   ├── raw/                        # Place creditcard.csv here
+│   └── processed/                  # Auto-generated preprocessed arrays
 ├── notebooks/
-│   └── 01_exploratory_analysis.ipynb
+│   └── 02_noise_sweep_results.ipynb  # Noise sweep analysis and conclusions
 ├── results/
-│   ├── figures/              # Saved plots
-│   └── metrics/              # JSON metric reports
+│   ├── figures/                    # Benchmark and ablation plots
+│   └── noise/
+│       └── noise_vs_metric.png     # Noise sweep: F1-Fraud and MCC vs p
 ├── src/
-│   ├── __init__.py
-│   ├── data_loader.py        # Dataset verification & download instructions
-│   ├── preprocessing.py      # Scaling · SMOTE · PCA pipeline
-│   ├── classical_models.py   # Random Forest & XGBoost builders
-│   ├── quantum_models.py     # VQC & QSVM implementations (PennyLane)
-│   └── evaluation.py         # Metrics, plots, comparison tables
+│   ├── data_loader.py              # Dataset verification
+│   ├── preprocessing.py            # Scaling · SMOTE · PCA pipeline
+│   ├── classical_models.py         # Random Forest & XGBoost
+│   ├── quantum_models.py           # VQC & QSVM (PennyLane)
+│   └── evaluation.py              # Metrics, plots, comparison tables
 ├── tests/
-│   ├── test_preprocessing.py
-│   ├── test_quantum_models.py
-│   └── test_evaluation.py
-├── requirements.txt
-└── README.md
+├── run_benchmark.py                # Main benchmark entrypoint
+├── run_ablation.py                 # Qubit count sweep (4–12 qubits)
+├── run_noise.py                    # Depolarizing noise sweep
+├── run_noise_parallel.sh           # Parallel noise sweep launcher
+├── run_noise_watcher.sh            # Queue-based watcher for long runs
+└── run_plots.py                    # Plot generation from saved results
 ```
 
 ---
@@ -56,13 +76,12 @@ qml-fraud-detection-benchmark/
 
 The benchmark uses the [Kaggle Credit Card Fraud Detection](https://www.kaggle.com/datasets/mlg-ulb/creditcardfraud) dataset.
 
-**Download steps:**
 ```bash
 # Option A – Kaggle CLI
 kaggle datasets download -d mlg-ulb/creditcardfraud --path data/raw --unzip
 
 # Option B – Manual
-# Download creditcard.csv from Kaggle and place it at data/raw/creditcard.csv
+# Download creditcard.csv from Kaggle and place at data/raw/creditcard.csv
 ```
 
 ---
@@ -70,39 +89,40 @@ kaggle datasets download -d mlg-ulb/creditcardfraud --path data/raw --unzip
 ## Setup
 
 ```bash
-# 1. Create a virtual environment
 python -m venv .venv
 source .venv/bin/activate      # Windows: .venv\Scripts\activate
-
-# 2. Install dependencies
 pip install -r requirements.txt
+pip install -e . --no-deps
+```
+
+---
+
+## Running the Benchmark
+
+```bash
+# Classical baselines only (fast)
+python run_benchmark.py --n-qubits 8 --classical-only --cv-folds 0 --no-plots
+
+# Full benchmark (classical + VQC + QSVM)
+python run_benchmark.py --n-qubits 8
+
+# Qubit ablation study
+python run_ablation.py
+
+# Depolarizing noise sweep (long — ~3 days on M4 Mac Mini)
+bash run_noise_parallel.sh
 ```
 
 ---
 
 ## Preprocessing Pipeline
 
-The `src/preprocessing.py` module addresses the core data challenges:
-
 | Challenge | Solution |
 |---|---|
-| Class imbalance (~0.17% fraud) | SMOTE oversampling (training set only) or class-weight |
+| Class imbalance (~0.17% fraud) | SMOTE oversampling (training set only) |
 | Outliers in transaction amounts | `RobustScaler` (median/IQR-based) |
-| High dimensionality (30 features) vs. qubit limit | PCA to 4–8 components |
+| High dimensionality (30 features) | PCA to n_qubits components |
 | Data leakage prevention | PCA & scaler fitted on train split only |
-
-```python
-from src.preprocessing import PreprocessingConfig, preprocess
-
-cfg = PreprocessingConfig(
-    data_path="data/raw/creditcard.csv",
-    n_qubits=8,                      # → 8 PCA components
-    imbalance_strategy="smote",
-)
-data = preprocess(cfg)
-# data.X_train  shape: (n_train, 8)  — qubit-ready
-# data.X_test   shape: (n_test,  8)
-```
 
 ---
 
@@ -114,52 +134,50 @@ data = preprocess(cfg)
 AngleEmbedding(X) → StronglyEntanglingLayers(weights) → ⟨Z₀⟩
 ```
 
-- Input: PCA-reduced features normalised to `[0, π]`
-- Ansatz: `StronglyEntanglingLayers` (expressibility optimised for NISQ)
-- Optimiser: Adam (PennyLane autograd)
+- 8 qubits, 2 layers, 30 training epochs, Adam optimiser
+- Backend: `lightning.qubit` (ideal), `default.mixed` (noisy simulation)
 
 ### Quantum SVM (QSVM)
 
-- Computes a quantum kernel matrix K(x, x') = |⟨φ(x)|φ(x')⟩|²
-- Feeds the kernel to a scikit-learn `SVC(kernel="precomputed")`
-- Feature map: double `AngleEmbedding` (ZZ-style, captures 2nd-order interactions)
+- Quantum kernel: K(x, x') = |⟨φ(x)|φ(x')⟩|²
+- Feature map: double `AngleEmbedding` (captures 2nd-order feature interactions)
+- Kernel matrix fed to scikit-learn `SVC(kernel="precomputed")`
 
 ---
 
-## Evaluation Metrics
+## Noise Sweep
 
-Accuracy is reported as a reference only.  Primary metrics:
+Depolarizing noise was swept across `p = [0.0, 0.001, 0.005, 0.01, 0.02, 0.05]`.
 
-| Metric | Why it matters for fraud detection |
-|---|---|
-| **F1 (fraud class)** | Balances precision and recall for the minority class |
-| **PR-AUC** | Summarises the precision-recall trade-off across all thresholds |
-| **ROC-AUC** | Overall discriminative ability |
-| **MCC** | Single balanced score accounting for all four confusion-matrix cells |
+![Noise sweep results](results/noise/noise_vs_metric.png)
+
+| Model | p=0.0 | p=0.001 | p=0.01 | p=0.05 |
+|---|---|---|---|---|
+| QSVM | 0.905 | 0.905 | 0.905 | 0.881 |
+| VQC  | 0.699 | 0.699 | 0.699 | 0.707 |
+
+**QSVM** degrades gracefully — only ~2.7% F1 drop from p=0.0 to p=0.05. **VQC** shows no meaningful noise degradation because it is already at its performance floor.
+
+At current best NISQ hardware noise (p ≈ 0.001), QSVM achieves F1-fraud = 0.905, remaining ~2% below Random Forest.
 
 ---
 
 ## Running Tests
 
 ```bash
-pytest tests/ -v --cov=src
+pytest tests/ -v
 ```
 
 ---
 
-## NISQ Considerations
+## Learnings
 
-- All quantum circuits are simulated using `lightning.qubit` (high-performance CPU backend).
-- The qubit budget is set to **4–8 qubits** to keep simulation tractable.
-- PCA dimensionality reduction is the key bridge between the 30-feature financial dataset and the qubit constraint.
-- Noise models and hardware transpilation are out of scope for this benchmark phase.
+1. **QSVM is surprisingly noise-tolerant.** Its kernel structure buffers it from depolarizing noise far better than the circuit-based VQC. If a quantum model were to be deployed on NISQ hardware, QSVM is the stronger candidate.
 
----
+2. **VQC's problem is not noise — it's capacity.** With 8 qubits and 30 epochs, VQC is underpowered for a 30-feature, heavily imbalanced fraud dataset. Noise makes virtually no difference because the model is already at its floor.
 
-## Roadmap
+3. **Classical models are not easily displaced.** XGBoost and Random Forest are well-matched to tabular fraud data: they handle imbalance, feature interactions, and high dimensionality natively. Quantum models need a structural advantage in the data to compete — which does not exist here.
 
-- [ ] Run full benchmark and save results to `results/metrics/`
-- [ ] Exploratory analysis notebook (`notebooks/01_exploratory_analysis.ipynb`)
-- [ ] Hardware execution on IBM Quantum (via PennyLane `qiskit.ibmq` plugin)
-- [ ] Autoencoder-based dimensionality reduction as PCA alternative
-- [ ] Noise-aware VQC training with depolarising error model
+4. **SMOTE miscalibrates quantum model thresholds.** Oversampling shifts the decision boundary such that default thresholds (0.5) produce poor precision/recall trade-offs. Post-training threshold tuning on the validation set is essential.
+
+5. **Parallel execution is necessary for noise sweeps.** Each noise level takes 26–37h on an M4 Mac Mini. Running all 6 levels in parallel reduces wall time from ~9 days to ~3.5 days.


### PR DESCRIPTION
Closes #17

## Summary

- Results table with F1, MCC, ROC-AUC, PR-AUC for all 4 models
- Noise sweep section with per-level breakdown and plot reference
- Project structure, setup instructions, and learnings updated to reflect the completed benchmark

## Test plan

- [x] README renders correctly on GitHub
- [x] All linked files and images exist in the repo